### PR TITLE
Refactor local blog generator

### DIFF
--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -27,7 +27,7 @@ class TestYoutube2BlogLocalJA(unittest.TestCase):
         self.assertTrue(filenames['text'].endswith("_article.txt"))
 
     def test_generate_blog_article_empty_transcript(self):
-        article, err = self.ja.generate_blog_article([], "https://youtu.be/aaaaaaaaaaa", no_timestamps=True, language="ja")
+        article, err = self.ja.generate_blog_article([], "https://youtu.be/aaaaaaaaaaa", language="ja")
         self.assertIsNone(article)
         self.assertIsNotNone(err)
 
@@ -54,7 +54,7 @@ class TestYoutube2BlogLocalZH(unittest.TestCase):
         self.assertTrue(filenames['text'].endswith("_article.txt"))
 
     def test_generate_blog_article_empty_transcript(self):
-        article, err = self.zh.generate_blog_article_zh([], "https://youtu.be/bbbbbbbbbbb", no_timestamps=True, language="zh")
+        article, err = self.zh.generate_blog_article_zh([], "https://youtu.be/bbbbbbbbbbb", language="zh")
         self.assertIsNone(article)
         self.assertIsNotNone(err)
 

--- a/youtube2blog_local.py
+++ b/youtube2blog_local.py
@@ -1,31 +1,81 @@
 import argparse
 import os
-import subprocess
 import tempfile
 import time
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 import whisper
 import yt_dlp
-import traceback
 import json
-import shutil
 from datetime import datetime
 from openai import OpenAI
-from PIL import Image, ImageDraw, ImageFont, ImageFilter, ImageEnhance
-import numpy as np
-from wordcloud import WordCloud
-from janome.tokenizer import Tokenizer
-import random
 import re
-import textwrap
-import hashlib
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 client = OpenAI()
 LLM_MODEL = "chatgpt-4o-latest"
 
 # 利用可能な音声のリスト
 AVAILABLE_VOICES = ["alloy", "ash", "ballad", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"]
+
+PROMPT_TEMPLATES = {
+    "zh": {
+        "word_count_instruction": "2. 请将全文控制在约{min_words}～{max_words}字。",
+        "intro": (
+            "请基于以下 YouTube 视频的逐字稿，撰写一篇中文解读型博客文章。"
+            "所有段落（包括标题）必须使用简体中文输出，除品牌英文名/符号名（如 @cosme、Dior）外，不得混用日文或英文。"
+            "若逐字稿或视频标题中包含日文，请翻译为自然的简体中文进行表达；标点请使用中文标点。"
+        ),
+        "common": (
+            "写作要求:\n"
+            "1. 采用第三人称与客观分析视角，穿插细节、示例与背景信息，突出重点并深入展开。\n"
+            "{word_count_instruction}\n"
+            "3. 在标题之后，直接写出视频的 URL（{youtube_url}）作为单独一行文本。\n"
+            "4. 第一节使用二级标题“## 要点”，以要点式列出核心论点与洞见；每条须具体、信息密度高，使读者仅读此节即可把握全貌。\n"
+            "5. 正文中可适度引入相关主题，给出独到见解、案例与应用，进行合理的延展与对比。\n"
+            "6. 最后一节使用二级标题“## 总结”，用简洁有力的语言收束全文，并提出可执行建议。\n"
+            "7. 不要使用加粗符号（*）；请合理使用“##”“###”等标题层级。\n"
+            "8. 生成的正文中不要包含任何转录段落标记（例如: [Segment 001 ...]）。"
+        ),
+        "output_format": (
+            "输出格式要求:\n"
+            "请将生成的整篇博客文章以如下 JSON 结构输出:\n"
+            "```json\n"
+            "{\n"
+            "  \"blog_article\": \"这里填写生成的整篇博客文章（使用 Markdown 格式）\"\n"
+            "}\n"
+            "```"
+        ),
+        "system": "你是一名专业中文博客作者，能够严格按照指示生成高质量内容，并以指定的 JSON 结构输出。",
+    },
+    "ja": {
+        "word_count_instruction": "2. 記事全体の文字数は{min_words}〜{max_words}字程度にしてください。",
+        "intro": "以下のYouTube動画の文字起こしを元に、日本語の解説ブログ記事を作成してください。",
+        "common": (
+            "ブログ記事の要件:\n"
+            "1. 読者が分かりやすいように、より詳細な説明や具体的な例を交えながら構成し、第三者視点で重要なポイントを深く掘り下げて強調してください。\n"
+            "{word_count_instruction}\n"
+            "3. タイトルの次に動画のURL ({youtube_url}) を文字列としてそのまま記載してください。\n"
+            "4. 最初の項目は「## ポイント」として、主な主張や論点の考察を箇条書きで記載し、ここだけ読めば概要がわかるようにしてください。各ポイントは具体的で、詳細な説明や背景情報も適宜含めてください。\n"
+            "5. 文字起こし内容に関連するトピックを適宜マッシュアップし、独自の見解や意見、さらには具体的な事例や応用例を交えながら述べてください。\n"
+            "6. 最後の項目は「## まとめ」として、記事全体の要点を簡潔に、かつ読者の行動を促すような形でまとめてください。\n"
+            "7. 太字表現 (*) は使用しないでください。見出し (## や ###) は適切に使用してください。\n"
+            "8. 生成するブログ記事の本文中には、文字起こしセグメントの情報（例: `[Segment 001 ...]`）を一切含めないでください。"
+        ),
+        "output_format": (
+            "出力形式の要件:\n"
+            "生成するブログ記事の全文を、以下のJSON形式で出力してください。\n"
+            "```json\n"
+            "{\n"
+            "  \"blog_article\": \"ここに生成されたブログ記事の全文をマークダウン形式で記述...\"\n"
+            "}\n"
+            "```"
+        ),
+        "system": "あなたはプロのブロガーであり、指示された形式で情報を正確に出力できるアシスタントです。",
+    },
+}
 
 def get_video_id(youtube_url: str) -> str:
     """YouTube URLから動画IDを抽出"""
@@ -63,34 +113,34 @@ def download_audio_from_youtube(youtube_url: str, output_dir: str = "temp_audio"
         }
         
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            print(f"YouTube動画をダウンロード中: {youtube_url}")
-            
+            logger.info("YouTube動画をダウンロード中: %s", youtube_url)
+
             # 動画情報を取得
             info = ydl.extract_info(youtube_url, download=False)
             video_title = info.get('title', 'Unknown')
-            print(f"動画タイトル: {video_title}")
-            
+            logger.info("動画タイトル: %s", video_title)
+
             # 音声をダウンロード
             ydl.download([youtube_url])
-            
-            print(f"ダウンロード完了、ファイルを探索中: {output_dir}")
+
+            logger.info("ダウンロード完了、ファイルを探索中: %s", output_dir)
             # ダウンロード後に実際にどんなファイルが作成されたかを確認
             files_in_dir = os.listdir(output_dir)
-            print(f"ディレクトリ内のファイル: {files_in_dir}")
+            logger.info("ディレクトリ内のファイル: %s", files_in_dir)
             
             # 予想されるファイル名
             expected_file = os.path.join(output_dir, f"audio_{video_id}.mp3")
             
             # ファイルが存在するか確認
             if os.path.exists(expected_file):
-                print(f"音声ファイルをダウンロード完了: {expected_file}")
+                logger.info("音声ファイルをダウンロード完了: %s", expected_file)
                 return expected_file, video_title
             else:
                 # mp3ファイルを探す（どんな名前でも）
                 for file in files_in_dir:
                     if file.endswith('.mp3'):
                         full_path = os.path.join(output_dir, file)
-                        print(f"MP3ファイルを発見: {full_path}")
+                        logger.info("MP3ファイルを発見: %s", full_path)
                         return full_path, video_title
                 
                 # まだ見つからない場合、他の音声ファイル形式も探す
@@ -99,15 +149,14 @@ def download_audio_from_youtube(youtube_url: str, output_dir: str = "temp_audio"
                     for ext in audio_extensions:
                         if file.endswith(ext):
                             full_path = os.path.join(output_dir, file)
-                            print(f"音声ファイルを発見: {full_path}")
+                            logger.info("音声ファイルを発見: %s", full_path)
                             return full_path, video_title
                 
                 raise FileNotFoundError(f"音声ファイルが見つかりません。ディレクトリ: {output_dir}, ファイル一覧: {files_in_dir}")
                 
     except Exception as e:
         error_msg = f"YouTubeからの音声ダウンロードに失敗しました: {str(e)}"
-        print(error_msg)
-        traceback.print_exc()
+        logger.exception(error_msg)
         raise Exception(error_msg)
 
 def transcribe_audio_with_whisper(audio_file_path: str, model_name: str = "base") -> tuple[List[Dict], str]:
@@ -116,15 +165,15 @@ def transcribe_audio_with_whisper(audio_file_path: str, model_name: str = "base"
     Returns: (transcript_data (youtube_transcript_api互換形式), detected_language)
     """
     try:
-        print(f"Whisperモデル '{model_name}' を読み込み中...")
+        logger.info("Whisperモデル '%s' を読み込み中...", model_name)
         model = whisper.load_model(model_name)
-        
-        print(f"音声ファイルを転写中: {audio_file_path}")
+
+        logger.info("音声ファイルを転写中: %s", audio_file_path)
         result = model.transcribe(audio_file_path, verbose=False)
-        
+
         # 検出された言語を取得
         detected_language = result.get('language', 'unknown')
-        print(f"検出された言語: {detected_language}")
+        logger.info("検出された言語: %s", detected_language)
         
         # youtube_transcript_api互換の形式に変換
         transcript_data = []
@@ -135,13 +184,12 @@ def transcribe_audio_with_whisper(audio_file_path: str, model_name: str = "base"
                 'duration': segment['end'] - segment['start']
             })
         
-        print(f"転写完了: {len(transcript_data)} セグメント生成されました")
+        logger.info("転写完了: %d セグメント生成されました", len(transcript_data))
         return transcript_data, detected_language
-        
+
     except Exception as e:
         error_msg = f"Whisperでの転写に失敗しました: {str(e)}"
-        print(error_msg)
-        traceback.print_exc()
+        logger.exception(error_msg)
         raise Exception(error_msg)
 
 def fetch_transcript_local(youtube_url: str, whisper_model: str = "base") -> dict:
@@ -149,44 +197,28 @@ def fetch_transcript_local(youtube_url: str, whisper_model: str = "base") -> dic
     ローカルでYouTubeトランスクリプトを生成
     Returns: {"error": None/str, "data": transcript_data, "language": "ja"}
     """
-    temp_dir = None
     try:
-        # 一時ディレクトリを作成
-        temp_dir = tempfile.mkdtemp(prefix="youtube_transcript_")
-        
-        # 音声をダウンロード
-        audio_file, video_title = download_audio_from_youtube(youtube_url, temp_dir)
-        
-        # Whisperで転写
-        transcript_data, detected_language = transcribe_audio_with_whisper(audio_file, whisper_model)
-        
-        if transcript_data:
-            return {
-                "error": None,
-                "data": transcript_data,
-                "language": detected_language,  # Whisperが検出した実際の言語を使用
-                "video_title": video_title
-            }
-        else:
-            return {"error": "転写データが空です", "data": None}
-            
+        with tempfile.TemporaryDirectory(prefix="youtube_transcript_") as temp_dir:
+            audio_file, video_title = download_audio_from_youtube(youtube_url, temp_dir)
+            transcript_data, detected_language = transcribe_audio_with_whisper(audio_file, whisper_model)
+
+            if transcript_data:
+                return {
+                    "error": None,
+                    "data": transcript_data,
+                    "language": detected_language,  # Whisperが検出した実際の言語を使用
+                    "video_title": video_title,
+                }
+            else:
+                return {"error": "転写データが空です", "data": None}
     except Exception as e:
         error_msg = f"ローカル転写中にエラーが発生しました: {str(e)}"
-        print(error_msg)
+        logger.error(error_msg)
         return {"error": error_msg, "data": None}
-    finally:
-        # 一時ディレクトリをクリーンアップ
-        if temp_dir and os.path.exists(temp_dir):
-            try:
-                shutil.rmtree(temp_dir)
-                print(f"一時ディレクトリを削除しました: {temp_dir}")
-            except Exception as cleanup_error:
-                print(f"一時ディレクトリの削除に失敗しました: {cleanup_error}")
 
 def generate_blog_article(
     transcript_data: list[dict],
     youtube_url: str,
-    no_timestamps: bool,
     language: str = "ja",
     min_words: int = 2500,
     max_words: int = 3000,
@@ -207,52 +239,13 @@ def generate_blog_article(
     transcript_string_for_llm = "\n".join(formatted_transcript_for_llm)
 
     # 言語に応じた指示を生成
-    if language in ("zh", "chinese", "zh-cn", "zh-tw"):
-        word_count_instruction = f"2. 请将全文控制在约{min_words}～{max_words}字。"
-        intro_to_transcript_processing = (
-            "请基于以下 YouTube 视频的逐字稿，撰写一篇中文解读型博客文章。"
-            "所有段落（包括标题）必须使用简体中文输出，除品牌英文名/符号名（如 @cosme、Dior）外，不得混用日文或英文。"
-            "若逐字稿或视频标题中包含日文，请翻译为自然的简体中文进行表达；标点请使用中文标点。"
-        )
-        common_blog_requirements = f"""写作要求:
-1. 采用第三人称与客观分析视角，穿插细节、示例与背景信息，突出重点并深入展开。
-{word_count_instruction}
-3. 在标题之后，直接写出视频的 URL（{youtube_url}）作为单独一行文本。
-4. 第一节使用二级标题“## 要点”，以要点式列出核心论点与洞见；每条须具体、信息密度高，使读者仅读此节即可把握全貌。
-5. 正文中可适度引入相关主题，给出独到见解、案例与应用，进行合理的延展与对比。
-6. 最后一节使用二级标题“## 总结”，用简洁有力的语言收束全文，并提出可执行建议。
-7. 不要使用加粗符号（*）；请合理使用“##”“###”等标题层级。
-8. 生成的正文中不要包含任何转录段落标记（例如: [Segment 001 ...]）。"""
-        output_format_requirements = (
-            """输出格式要求:
-请将生成的整篇博客文章以如下 JSON 结构输出:
-```json
-{
-  "blog_article": "这里填写生成的整篇博客文章（使用 Markdown 格式）"
-}
-```"""
-        )
-        system_prompt = "你是一名专业中文博客作者，能够严格按照指示生成高质量内容，并以指定的 JSON 结构输出。"
-    else:
-        word_count_instruction = f"2. 記事全体の文字数は{min_words}〜{max_words}字程度にしてください。"
-        intro_to_transcript_processing = "以下のYouTube動画の文字起こしを元に、日本語の解説ブログ記事を作成してください。"
-        common_blog_requirements = f"""ブログ記事の要件:
-1. 読者が分かりやすいように、より詳細な説明や具体的な例を交えながら構成し、第三者視点で重要なポイントを深く掘り下げて強調してください。
-{word_count_instruction}
-3. タイトルの次に動画のURL ({youtube_url}) を文字列としてそのまま記載してください。
-4. 最初の項目は「## ポイント」として、主な主張や論点の考察を箇条書きで記載し、ここだけ読めば概要がわかるようにしてください。各ポイントは具体的で、詳細な説明や背景情報も適宜含めてください。
-5. 文字起こし内容に関連するトピックを適宜マッシュアップし、独自の見解や意見、さらには具体的な事例や応用例を交えながら述べてください。
-6. 最後の項目は「## まとめ」として、記事全体の要点を簡潔に、かつ読者の行動を促すような形でまとめてください。
-7. 太字表現 (*) は使用しないでください。見出し (## や ###) は適切に使用してください。
-8. 生成するブログ記事の本文中には、文字起こしセグメントの情報（例: `[Segment 001 ...]`）を一切含めないでください。"""
-        output_format_requirements = f"""出力形式の要件:
-生成するブログ記事の全文を、以下のJSON形式で出力してください。
-```json
-{{
-  "blog_article": "ここに生成されたブログ記事の全文をマークダウン形式で記述..."
-}}
-```"""
-        system_prompt = "あなたはプロのブロガーであり、指示された形式で情報を正確に出力できるアシスタントです。"
+    lang_key = "zh" if language in ("zh", "chinese", "zh-cn", "zh-tw") else "ja"
+    config = PROMPT_TEMPLATES[lang_key]
+    word_count_instruction = config["word_count_instruction"].format(min_words=min_words, max_words=max_words)
+    intro_to_transcript_processing = config["intro"]
+    common_blog_requirements = config["common"].format(word_count_instruction=word_count_instruction, youtube_url=youtube_url)
+    output_format_requirements = config["output_format"]
+    system_prompt = config["system"]
 
     prompt_content = f"""{intro_to_transcript_processing}
 {common_blog_requirements}
@@ -268,7 +261,7 @@ def generate_blog_article(
     ]
 
     try:
-        print("LLMにブログ記事の生成をリクエストします...")
+        logger.info("LLMにブログ記事の生成をリクエストします...")
         response = client.chat.completions.create(
             model=LLM_MODEL,
             messages=messages,
@@ -284,7 +277,7 @@ def generate_blog_article(
             blog_article_text = parsed_response.get("blog_article")
             
             if not blog_article_text:
-                print("エラー: LLMからの応答形式が不正です（blog_articleが欠損）。")
+                logger.error("エラー: LLMからの応答形式が不正です（blog_articleが欠損）。")
                 return None, "LLMからの応答形式が不正です（blog_articleが欠損）。"
             
             # セグメント注釈を削除
@@ -294,19 +287,19 @@ def generate_blog_article(
             # 中国語出力時の日本語混在を検出（ひらがな/カタカナ）し、必要ならリライト
             if language in ("zh", "chinese", "zh-cn", "zh-tw"):
                 if re.search(r"[\u3040-\u309F\u30A0-\u30FF]", blog_article_text):
-                    print("検出: 中国語記事に日本語が混在。中国語のみに統一します…")
+                    logger.info("検出: 中国語記事に日本語が混在。中国語のみに統一します…")
                     blog_article_text = _refine_to_simplified_chinese(blog_article_text)
 
-            print("ブログ記事を正常に生成・パースしました。")
+            logger.info("ブログ記事を正常に生成・パースしました。")
             return blog_article_text, None
-            
+
         except json.JSONDecodeError as json_e:
-            print(f"LLMからの応答のJSONパースに失敗しました: {json_e}")
+            logger.exception("LLMからの応答のJSONパースに失敗しました: %s", json_e)
             return None, f"LLM応答のJSONパース失敗: {json_e}"
-            
+
     except Exception as e_llm:
         error_msg = f"ブログ記事の生成中にエラーが発生しました: {e_llm}"
-        print(error_msg)
+        logger.error(error_msg)
         return None, error_msg
 
 
@@ -351,16 +344,16 @@ def save_to_file(content, filename):
     try:
         with open(filename, 'w', encoding='utf-8') as file:
             file.write(content)
-        print(f"ブログ記事が {filename} に保存されました。")
+        logger.info("ブログ記事が %s に保存されました。", filename)
     except Exception as e:
-        print(f"ファイル保存中にエラーが発生しました: {e}")
+        logger.error("ファイル保存中にエラーが発生しました: %s", e)
 
 def _generate_output_filenames(youtube_url: str, output_language: str = "ja") -> dict[str, str]:
     """動画IDとオプションに基づいて出力ファイル名を生成（中国語は _zh サフィックス）"""
     try:
         video_id = get_video_id(youtube_url)
     except ValueError as e:
-        print(f"ファイル名生成エラー: {e}")
+        logger.error("ファイル名生成エラー: %s", e)
         return {'text': None}
     
     today = datetime.now().strftime('%Y%m%d')
@@ -394,59 +387,58 @@ def main():
     # 出力ファイル名を生成
     output_filenames = _generate_output_filenames(args.youtube_url, args.output_language)
     if any(value is None for value in output_filenames.values()):
-        print("ファイル名の生成に失敗しました。処理を中断します。")
+        logger.error("ファイル名の生成に失敗しました。処理を中断します。")
         return
     
     article_file = output_filenames['text']
     
-    print(f"\n=== YouTube動画からローカルで文字起こしを生成 ===")
-    print(f"動画URL: {args.youtube_url}")
-    print(f"Whisperモデル: {args.whisper_model}")
-    print(f"出力言語: {args.output_language}")
+    logger.info("\n=== YouTube動画からローカルで文字起こしを生成 ===")
+    logger.info("動画URL: %s", args.youtube_url)
+    logger.info("Whisperモデル: %s", args.whisper_model)
+    logger.info("出力言語: %s", args.output_language)
     
     # ローカルでトランスクリプトを生成
-    print("\n文字起こしを生成中...")
+    logger.info("\n文字起こしを生成中...")
     transcript_response = fetch_transcript_local(args.youtube_url, args.whisper_model)
     
     if transcript_response.get('error'):
-        print(f"文字起こし生成エラー: {transcript_response['error']}")
+        logger.error("文字起こし生成エラー: %s", transcript_response['error'])
         return
-    
+
     transcript_data = transcript_response.get('data')
     if not transcript_data:
-        print("文字起こしデータが取得できませんでした（データが空です）。")
+        logger.error("文字起こしデータが取得できませんでした（データが空です）。")
         return
-    
-    print(f"文字起こし生成成功。セグメント数: {len(transcript_data)}")
+
+    logger.info("文字起こし生成成功。セグメント数: %d", len(transcript_data))
     
     # ブログ記事を生成
-    print(f"\nブログ記事（{args.output_language}）を生成中...")
+    logger.info("\nブログ記事（%s）を生成中...", args.output_language)
     blog_article_text, error_message = generate_blog_article(
         transcript_data,
         args.youtube_url,
-        no_timestamps=True,
         language=args.output_language,
         min_words=args.min_words,
-        max_words=args.max_words
+        max_words=args.max_words,
     )
     
     if error_message:
-        print(f"ブログ記事生成エラー: {error_message}")
+        logger.error("ブログ記事生成エラー: %s", error_message)
         if blog_article_text:
-            print("部分的なブログ記事を保存します...")
+            logger.info("部分的なブログ記事を保存します...")
             save_to_file(blog_article_text, article_file)
         return
-    
+
     if not blog_article_text:
-        print("ブログ記事の生成に失敗しました（テキストが空です）。")
+        logger.error("ブログ記事の生成に失敗しました（テキストが空です）。")
         return
-    
-    print("ブログ記事生成成功。")
+
+    logger.info("ブログ記事生成成功。")
     save_to_file(blog_article_text, article_file)
-    
+
     elapsed_time = time.time() - start_time
-    print(f"\n処理が完了しました。所要時間: {elapsed_time:.2f}秒")
-    print(f"ブログ記事保存先: {article_file}")
+    logger.info("\n処理が完了しました。所要時間: %.2f秒", elapsed_time)
+    logger.info("ブログ記事保存先: %s", article_file)
 
 if __name__ == "__main__":
     main() 


### PR DESCRIPTION
## Summary
- remove unused imports and switch to logging for consistent output
- use TemporaryDirectory for safer transcript cleanup
- unify blog prompts across languages via templates and drop unused `no_timestamps`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fd62ba50832fbd9d2aeca16bbb4d